### PR TITLE
Ensure plugin palette cache is registered and watched

### DIFF
--- a/lib/bindings/app_binding.dart
+++ b/lib/bindings/app_binding.dart
@@ -5,6 +5,7 @@ import 'package:moviepilot_mobile/services/app_service.dart';
 import '../modules/login/controllers/login_controller.dart';
 import '../modules/login/repositories/auth_repository.dart';
 import '../modules/media_detail/controllers/media_detail_service.dart';
+import '../modules/plugin/services/plugin_palette_cache.dart';
 import '../services/realm_service.dart';
 
 class AppBinding extends Bindings {
@@ -16,5 +17,6 @@ class AppBinding extends Bindings {
     Get.put(AuthRepository(), permanent: true);
     Get.put(LoginController(), permanent: true);
     Get.put(MediaDetailService(), permanent: true);
+    Get.put(PluginPaletteCache(), permanent: true);
   }
 }

--- a/lib/modules/media_detail/controllers/media_detail_controller.dart
+++ b/lib/modules/media_detail/controllers/media_detail_controller.dart
@@ -642,7 +642,7 @@ class MediaDetailController extends GetxController {
           payload: {
             'doubanid': detail.douban_id?.toString() ?? '',
             'name': detail.title?.trim() ?? '',
-            'season': season?.toString() ?? '',
+            'season': season ?? 0,
             'year': detail.year?.trim() ?? '',
             'tmdbid': detail.tmdb_id?.toString(),
           },

--- a/lib/modules/plugin/controllers/plugin_controller.dart
+++ b/lib/modules/plugin/controllers/plugin_controller.dart
@@ -163,7 +163,9 @@ class PluginController extends GetxController {
 
   void _preloadPalettes() {
     try {
-      final cache = Get.find<PluginPaletteCache>();
+      final cache = Get.isRegistered<PluginPaletteCache>()
+          ? Get.find<PluginPaletteCache>()
+          : Get.put(PluginPaletteCache(), permanent: true);
       final urls = visibleItems
           .map(
             (e) => e.pluginIcon != null && e.pluginIcon!.isNotEmpty

--- a/lib/modules/plugin/controllers/plugin_list_controller.dart
+++ b/lib/modules/plugin/controllers/plugin_list_controller.dart
@@ -216,7 +216,9 @@ class PluginListController extends GetxController {
 
   void _preloadPalettes() {
     try {
-      final cache = Get.find<PluginPaletteCache>();
+      final cache = Get.isRegistered<PluginPaletteCache>()
+          ? Get.find<PluginPaletteCache>()
+          : Get.put(PluginPaletteCache(), permanent: true);
       final urls = visibleItems
           .map(
             (e) => e.pluginIcon != null && e.pluginIcon!.isNotEmpty

--- a/lib/modules/plugin/widgets/plugin_item_card.dart
+++ b/lib/modules/plugin/widgets/plugin_item_card.dart
@@ -34,30 +34,32 @@ class PluginItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final themeColor = _resolveThemeColor();
-    return RepaintBoundary(
-      child: Section(
-        padding: const EdgeInsets.all(0),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(_cardRadius),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _buildDarkSection(context, themeColor),
-              _buildLightSection(context),
-            ],
+    return Obx(() {
+      final themeColor = _resolveThemeColor();
+      return RepaintBoundary(
+        child: Section(
+          padding: const EdgeInsets.all(0),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(_cardRadius),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _buildDarkSection(context, themeColor),
+                _buildLightSection(context),
+              ],
+            ),
           ),
         ),
-      ),
-    );
+      );
+    });
   }
 
   /// 仅读缓存，不订阅 Rx，避免任一 palette 更新导致所有卡片重建引发卡顿
   Color _resolveThemeColor() {
     try {
       final cache = Get.find<PluginPaletteCache>();
-      return cache.getCached(iconUrl) ?? PluginPaletteCache.defaultColor;
+      return cache.watchColor(iconUrl) ?? PluginPaletteCache.defaultColor;
     } catch (_) {
       return PluginPaletteCache.defaultColor;
     }


### PR DESCRIPTION
Summary
- put `PluginPaletteCache` into `AppBinding` so it is always registered
- guard palette lookups in controllers to lazily register the cache when needed
- wrap `PluginItemCard` in `Obx` and use `watchColor` so cached palettes drive UI updates instead of rebuilding all cards

Testing
- Not run (not requested)