### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,24 @@
 ## API/Server 约定
 - Server 文档地址：https://api.movie-pilot.org
 - 所有 HTTP 请求必须严格按照 Swagger 文档定义执行（接口路径、方法、参数、请求体、Header、鉴权等均以 Swagger 为准）。
+
+## Cursor Cloud specific instructions
+
+### Environment
+- Flutter 3.38.2 installed at `/opt/flutter`, Dart 3.10.0 bundled
+- Android SDK at `/opt/android-sdk` (SDK 36, build-tools 36.0.0, NDK 28.2)
+- PATH and ANDROID_HOME are set in `~/.bashrc`
+
+### Commands
+- **Install deps**: `flutter pub get`
+- **Code gen** (freezed/json_serializable/flutter_gen): `dart run build_runner build --delete-conflicting-outputs`
+- **Lint**: `flutter analyze`
+- **Test**: `flutter test`
+- **Build debug APK**: `flutter build apk --debug`
+- **Build release APK**: `flutter build apk --release --dart-define=FLUTTER_APP_ENV=release`
+
+### Gotchas
+- `dart run build_runner build` regenerates `*.freezed.dart` files. The committed `form_block_models.freezed.dart` has a known duplicate class issue (`InfoCardRowMenu` used for both `menu` and `group` constructors in `InfoCardRow`). **Do not regenerate** this file unless the source model is fixed — the build succeeds only with the committed version.
+- The project targets **Android/iOS/macOS only** — no web or linux platform. Cannot run interactively in a headless VM; use `flutter build apk --debug` to verify builds.
+- First Android build downloads Realm native binaries and CMake automatically — this can take ~2 minutes extra.
+- `pubspec.lock` may show minor version drifts after `flutter pub get`; restore with `git checkout -- pubspec.lock` if you don't intend to update deps.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `## Cursor Cloud specific instructions` section to `AGENTS.md` with:
- Flutter/Android SDK environment paths
- Common dev commands (pub get, build_runner, analyze, test, build)
- Known gotchas (freezed codegen issue, platform limitations, first-build delays)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-514f5443-5fd8-4025-923b-af4dc24d6292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-514f5443-5fd8-4025-923b-af4dc24d6292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

