### PR TITLE
fix: 兼容 MoviePilot v3 媒体身份契约，修复 v3 服务端下详情页 422

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- 兼容 MoviePilot v3 的媒体身份契约，同时保留 MoviePilot v2 请求行为。
+- 修复 MoviePilot v3 服务端下媒体详情页因身份参数不匹配返回 422 的问题。
 - 新增已安装插件「备份中心」：本地 JSON 备份/导入、备份列表长按删除、多选批量恢复安装；AppBar 直接露出指定安装、备份中心、插件市场，并以主色/冷色/暖色区分。
 - 插件恢复缺 `repo_url` 时自动反推（市场缓存、PLUGIN_MARKET、官方仓、author_url），安装按候选仓依次尝试；进度条内实时显示成功/失败且完成后保留。
 - 备份中心与恢复选插件 Sheet 视觉升级：独立恢复 Sheet、不透明卡片底、圆形勾选、安装按钮 `onPrimary` 配色、删除确认 Dialog。

--- a/lib/bindings/app_binding.dart
+++ b/lib/bindings/app_binding.dart
@@ -2,6 +2,7 @@ import 'package:get/get.dart';
 import 'package:moviepilot_mobile/applog/app_log.dart';
 import 'package:altman_totp/services/totp_service.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
 
 import '../modules/login/controllers/login_controller.dart';
 import '../modules/login/repositories/auth_repository.dart';
@@ -15,6 +16,7 @@ class AppBinding extends Bindings {
     Get.put(AppLog(), permanent: true);
     Get.put(AppService(), permanent: true);
     Get.put(TotpService(), permanent: true);
+    Get.put(ServerApiVersionService(), permanent: true);
     Get.put(AuthRepository(), permanent: true);
     Get.put(LoginController(), permanent: true);
     Get.put(MediaDetailService(), permanent: true);

--- a/lib/modules/discover/controllers/discover_controller.dart
+++ b/lib/modules/discover/controllers/discover_controller.dart
@@ -12,6 +12,7 @@ import 'package:moviepilot_mobile/modules/recommend/models/recommend_api_item.da
 import 'package:moviepilot_mobile/modules/search/services/search_keyword_hints_service.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 enum DiscoverSource {
@@ -838,7 +839,7 @@ class DiscoverController extends GetxController {
       if (raw is! Map) continue;
       final map = _toStringKeyMap(raw);
       try {
-        final apiItem = RecommendApiItem.fromJson(map);
+        final apiItem = RecommendApiItem.fromJson(normalizeMediaJson(map));
         final patched = (apiItem.type == null || apiItem.type!.isEmpty)
             ? apiItem.copyWith(type: fallbackMediaType)
             : apiItem;

--- a/lib/modules/login/repositories/auth_repository.dart
+++ b/lib/modules/login/repositories/auth_repository.dart
@@ -12,6 +12,7 @@ import 'package:moviepilot_mobile/modules/site/controllers/site_controller.dart'
 import 'package:moviepilot_mobile/modules/system_message/controllers/system_message_controller.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
 import 'package:moviepilot_mobile/services/ios_shared_session_service.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
 import '../../../services/api_client.dart';
 import '../../../services/hive_service.dart';
 import '../models/login_profile.dart';
@@ -22,6 +23,8 @@ class AuthRepository extends GetxService {
   final _api = Get.find<ApiClient>();
   final _appService = Get.find<AppService>();
   final _iosSharedSessionService = Get.find<IosSharedSessionService>();
+  ServerApiVersionService get _serverApiVersionService =>
+      Get.find<ServerApiVersionService>();
 
   Box<LoginProfile> get _loginBox => Get.find<HiveService>().loginProfileBox;
 
@@ -53,6 +56,7 @@ class AuthRepository extends GetxService {
     );
     final login = LoginResponse.fromJson(response.data!);
     _talker.info('登录成功: $username');
+    _serverApiVersionService.reset();
     // 登录成功后，后续请求统一携带 Token
     _api.setToken(login.accessToken);
 
@@ -138,6 +142,7 @@ class AuthRepository extends GetxService {
       final userLookupKey = normalizedUserName.isNotEmpty
           ? normalizedUserName
           : normalizedLoginName;
+      _serverApiVersionService.reset();
       _appService.restoreSessionFromProfile(profile);
       _api.setBaseUrl(normalizedServer);
       _api.setToken(profile.accessToken);
@@ -188,6 +193,7 @@ class AuthRepository extends GetxService {
 
   void restoreLocalSession({required LoginProfile profile}) {
     final normalizedServer = _normalizeServer(profile.server);
+    _serverApiVersionService.reset();
     _appService.restoreSessionFromProfile(profile);
     _api.setBaseUrl(normalizedServer);
     _api.setToken(profile.accessToken);
@@ -211,6 +217,7 @@ class AuthRepository extends GetxService {
     await _api.clearSessionCookies();
     _api.setToken('');
     _appService.clearCookie();
+    _serverApiVersionService.reset();
     _appService.restoreSessionFromProfile(profile);
     _api.setBaseUrl(normalizedServer);
     _api.setToken(profile.accessToken);

--- a/lib/modules/media_detail/controllers/media_detail_controller.dart
+++ b/lib/modules/media_detail/controllers/media_detail_controller.dart
@@ -16,6 +16,8 @@ import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_models.dart
 import 'package:moviepilot_mobile/services/app_service.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/hive_service.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:moviepilot_mobile/utils/toast_util.dart';
 
 class MediaDetailController extends GetxController {
@@ -29,6 +31,8 @@ class MediaDetailController extends GetxController {
   final _hiveService = Get.find<HiveService>();
   final _mediaDetailService = Get.find<MediaDetailService>();
   final _subscribeService = Get.put(SubscribeService());
+  ServerApiVersionService get _serverApiVersionService =>
+      Get.find<ServerApiVersionService>();
   final subscribeLoadingState = false.obs;
   final isLoading = false.obs;
   final mediaDetail = Rxn<MediaDetail>();
@@ -152,7 +156,7 @@ class MediaDetailController extends GetxController {
       final decoded = jsonDecode(cache.payload);
       if (decoded is Map) {
         mediaDetail.value = MediaDetail.fromJson(
-          Map<String, dynamic>.from(decoded),
+          normalizeMediaJson(Map<String, dynamic>.from(decoded)),
         );
       }
     } catch (e, st) {
@@ -165,7 +169,7 @@ class MediaDetailController extends GetxController {
     final cacheKey = _cacheKey(_args);
     if (cacheKey.isEmpty) return;
     try {
-      final payload = jsonEncode(detail.toJson());
+      final payload = jsonEncode(normalizeMediaJson(detail.toJson()));
       final server = (_appService.baseUrl ?? _apiClient.baseUrl ?? '').trim();
       final cache = MediaDetailCache(
         cacheKey,
@@ -222,13 +226,26 @@ class MediaDetailController extends GetxController {
     statusCode.value = null;
 
     try {
-      final path = _buildPath(_args);
-      final query = _buildQuery(_args);
-      final response = await _apiClient.get<dynamic>(
-        path,
-        queryParameters: query,
+      final identity = MediaIdentity.parse(_normalizePath(_args.path));
+      var useV3 = identity != null && await _serverApiVersionService.isV3();
+      final requestBaseUrl = _apiClient.baseUrl;
+      var response = await _apiClient.get<dynamic>(
+        _buildPath(_args, useV3: useV3),
+        queryParameters: _buildQuery(_args, useV3: useV3),
         timeout: 120,
       );
+      if (response.statusCode == 422 && identity != null) {
+        useV3 = !useV3;
+        response = await _apiClient.get<dynamic>(
+          _buildPath(_args, useV3: useV3),
+          queryParameters: _buildQuery(_args, useV3: useV3),
+          timeout: 120,
+        );
+        final retryStatus = response.statusCode ?? 0;
+        if (retryStatus >= 200 && retryStatus < 300) {
+          _serverApiVersionService.markV3(requestBaseUrl, useV3);
+        }
+      }
 
       statusCode.value = response.statusCode ?? 0;
       final detail = _parseResponse(response.data);
@@ -267,19 +284,34 @@ class MediaDetailController extends GetxController {
 
   Future<void> refreshDetail() => fetchDetail();
 
-  String _buildPath(MediaDetailArgs args) {
+  String _buildPath(MediaDetailArgs args, {bool useV3 = false}) {
     final path = _normalizePath(args.path);
     if (path.isEmpty) return '/api/v1/media/';
+    if (useV3) {
+      final identity = MediaIdentity.parse(path);
+      if (identity != null) return '/api/v1/media/${identity.id}';
+    }
     return '/api/v1/media/$path';
   }
 
-  Map<String, dynamic> _buildQuery(MediaDetailArgs args) {
+  Map<String, dynamic> _buildQuery(
+    MediaDetailArgs args, {
+    bool useV3 = false,
+  }) {
     final query = <String, dynamic>{};
     if (args.title.trim().isNotEmpty) {
       query['title'] = args.title.trim();
     }
     if (args.year?.trim().isNotEmpty == true) {
       query['year'] = args.year!.trim();
+    }
+    if (useV3) {
+      final identity = MediaIdentity.parse(_normalizePath(args.path));
+      if (identity != null) query['media_source'] = identity.source;
+      query['type_name'] = args.typeName?.trim().isNotEmpty == true
+          ? args.typeName!.trim()
+          : '未知';
+      return query;
     }
     if (args.typeName?.trim().isNotEmpty == true) {
       query['type_name'] = args.typeName!.trim();
@@ -324,7 +356,9 @@ class MediaDetailController extends GetxController {
     try {
       if (data is Map) {
         try {
-          final detail = MediaDetail.fromJson(Map<String, dynamic>.from(data));
+          final detail = MediaDetail.fromJson(
+            normalizeMediaJson(Map<String, dynamic>.from(data)),
+          );
           return detail;
         } catch (error) {
           _log.handle(error, message: '解析媒体详情失败');
@@ -336,7 +370,9 @@ class MediaDetailController extends GetxController {
         if (!_looksLikeJson(trimmed)) return null;
         final decoded = jsonDecode(trimmed);
         if (decoded is Map) {
-          return MediaDetail.fromJson(Map<String, dynamic>.from(decoded));
+          return MediaDetail.fromJson(
+            normalizeMediaJson(Map<String, dynamic>.from(decoded)),
+          );
         }
       }
     } catch (_) {
@@ -361,7 +397,9 @@ class MediaDetailController extends GetxController {
       return;
     }
     try {
-      final payload = detail.toJson();
+      final payload = await _serverApiVersionService.isV3()
+          ? sanitizeMediaIdentityPayload(detail.toJson())
+          : detail.toJson();
       final list = await _mediaDetailService.getMediaNotExists(payload);
       mediaNotExists.assignAll(list);
     } catch (e) {
@@ -540,7 +578,9 @@ class MediaDetailController extends GetxController {
     return list
         .whereType<Map>()
         .map(
-          (item) => RecommendApiItem.fromJson(Map<String, dynamic>.from(item)),
+          (item) => RecommendApiItem.fromJson(
+            normalizeMediaJson(Map<String, dynamic>.from(item)),
+          ),
         )
         .toList();
   }
@@ -765,6 +805,13 @@ class MediaDetailController extends GetxController {
         final inferred = _mediaTypeName(detail);
         if (inferred.isNotEmpty) query['mtype'] = inferred;
       }
+      if (await _serverApiVersionService.isV3()) {
+        final identity = _identityForDetail(detail);
+        if (identity != null) {
+          query['media_source'] = identity.source;
+          query['media_id'] = identity.id;
+        }
+      }
       final response = await _apiClient.get<dynamic>(
         _mediaserverExistsPath,
         token: token,
@@ -781,6 +828,16 @@ class MediaDetailController extends GetxController {
       _log.handle(e, stackTrace: st, message: '媒体入库状态查询失败');
       mediaserverInLibrary.value = false;
     }
+  }
+
+  MediaIdentity? _identityForDetail(MediaDetail detail) {
+    final source = normalizeMediaSource(detail.source);
+    final mediaId = detail.media_id?.trim();
+    if (source != null && mediaId != null && mediaId.isNotEmpty) {
+      final identity = MediaIdentity.parse('$source:$mediaId');
+      if (identity != null) return identity;
+    }
+    return MediaIdentity.parse(_args.path);
   }
 
   String _existsTitleForDetail(MediaDetail detail) {

--- a/lib/modules/media_detail/controllers/media_detail_service.dart
+++ b/lib/modules/media_detail/controllers/media_detail_service.dart
@@ -7,12 +7,16 @@ import 'package:moviepilot_mobile/modules/subscribe/controllers/subscribe_servic
 import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_models.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 
 class MediaDetailService extends GetxService {
   final _apiClient = Get.find<ApiClient>();
   final _appService = Get.find<AppService>();
   final _log = Get.find<AppLog>();
   final _subscribeService = Get.put(SubscribeService());
+  ServerApiVersionService get _serverApiVersionService =>
+      Get.find<ServerApiVersionService>();
 
   String? _getToken() =>
       _appService.loginResponse?.accessToken ??
@@ -71,19 +75,28 @@ class MediaDetailService extends GetxService {
   }
 
   /// GET /api/v1/media/seasons 获取媒体可订阅的季度列表。
-  /// mediaid 使用详情页原始媒体标识（如 tmdb:2734、douban:xxxx），
-  /// 不在客户端拆分或重组，避免不同来源的参数规则被混用。
+  /// v2 使用原始 mediaid；v3 拆分为 media_source 与 media_id。
   Future<List<SeasonInfo>> getMediaSeasons({
     required String mediaId,
     required String title,
     required String year,
   }) async {
     try {
-      final query = <String, dynamic>{
-        'mediaid': mediaId,
-        if (title.trim().isNotEmpty) 'title': title.trim(),
-        if (year.trim().isNotEmpty) 'year': year.trim(),
-      };
+      final identity = MediaIdentity.parse(mediaId);
+      final useV3 =
+          identity != null && await _serverApiVersionService.isV3();
+      final query = useV3
+          ? <String, dynamic>{
+              'media_source': identity.source,
+              'media_id': identity.id,
+              if (title.trim().isNotEmpty) 'title': title.trim(),
+              if (year.trim().isNotEmpty) 'year': year.trim(),
+            }
+          : <String, dynamic>{
+              'mediaid': mediaId,
+              if (title.trim().isNotEmpty) 'title': title.trim(),
+              if (year.trim().isNotEmpty) 'year': year.trim(),
+            };
       final response = await _apiClient.get<dynamic>(
         '/api/v1/media/seasons',
         queryParameters: query,

--- a/lib/modules/recommend/controllers/recommend_category_list_controller.dart
+++ b/lib/modules/recommend/controllers/recommend_category_list_controller.dart
@@ -9,6 +9,7 @@ import 'package:moviepilot_mobile/modules/recommend/models/recommend_api_item.da
 import 'package:moviepilot_mobile/modules/search_result/controllers/search_result_controller.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// 推荐分类列表控制器，支持分页加载
@@ -147,7 +148,11 @@ class RecommendCategoryListController extends GetxController {
       final list = _extractList(payload);
       final parsed = list
           .whereType<Map>()
-          .map((e) => RecommendApiItem.fromJson(Map<String, dynamic>.from(e)))
+          .map(
+            (e) => RecommendApiItem.fromJson(
+              normalizeMediaJson(Map<String, dynamic>.from(e)),
+            ),
+          )
           .toList();
 
       if (append) {

--- a/lib/modules/recommend/controllers/recommend_controller.dart
+++ b/lib/modules/recommend/controllers/recommend_controller.dart
@@ -13,6 +13,7 @@ import 'package:moviepilot_mobile/modules/search/services/search_keyword_hints_s
 import 'package:moviepilot_mobile/modules/subscribe/controllers/subscribe_service.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:path_provider/path_provider.dart';
 
 const List<String> _movieSubCategories = <String>[
@@ -584,7 +585,7 @@ class RecommendController extends GetxController {
       if (raw is! Map) continue;
       final map = _toStringKeyMap(raw);
       try {
-        final apiItem = RecommendApiItem.fromJson(map);
+        final apiItem = RecommendApiItem.fromJson(normalizeMediaJson(map));
         items.add(apiItem);
       } catch (e, st) {
         _log.handle(e, stackTrace: st, message: '解析推荐条目失败');

--- a/lib/modules/search/controllers/media_search_list_controller.dart
+++ b/lib/modules/search/controllers/media_search_list_controller.dart
@@ -8,6 +8,7 @@ import 'package:moviepilot_mobile/modules/search_result/controllers/search_resul
 import 'package:moviepilot_mobile/modules/subscribe/controllers/subscribe_service.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class MediaSearchListController extends GetxController {
@@ -152,7 +153,9 @@ class MediaSearchListController extends GetxController {
       final raw = response.data;
       final parsed = _extractList(raw)
           .whereType<Map<String, dynamic>>()
-          .map(RecommendApiItem.fromJson)
+          .map(
+            (item) => RecommendApiItem.fromJson(normalizeMediaJson(item)),
+          )
           .toList();
       if (append) {
         items.addAll(parsed);

--- a/lib/modules/search/controllers/person_detail_controller.dart
+++ b/lib/modules/search/controllers/person_detail_controller.dart
@@ -2,6 +2,7 @@ import 'package:get/get.dart';
 import 'package:moviepilot_mobile/modules/recommend/models/recommend_api_item.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/utils/image_util.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:moviepilot_mobile/modules/search/models/person_detail.dart';
 
 class PersonDetailController extends GetxController {
@@ -115,7 +116,9 @@ class PersonDetailController extends GetxController {
       final rawWorks = worksResp.data;
       final parsedWorks = _extractList(rawWorks)
           .whereType<Map<String, dynamic>>()
-          .map(RecommendApiItem.fromJson)
+          .map(
+            (item) => RecommendApiItem.fromJson(normalizeMediaJson(item)),
+          )
           .toList();
       if (append) {
         works.addAll(parsedWorks);

--- a/lib/modules/search/controllers/search_controller.dart
+++ b/lib/modules/search/controllers/search_controller.dart
@@ -9,7 +9,9 @@ import 'package:moviepilot_mobile/modules/search_result/controllers/search_resul
 import 'package:moviepilot_mobile/modules/search_result/models/search_result_models.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
 import 'package:moviepilot_mobile/services/sse_client.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 enum SearchType { media, title }
@@ -21,6 +23,8 @@ class SearchMediaController extends GetxController {
   final _apiClient = Get.find<ApiClient>();
   final _appService = Get.find<AppService>();
   final _log = Get.find<AppLog>();
+  ServerApiVersionService get _serverApiVersionService =>
+      Get.find<ServerApiVersionService>();
 
   final searchText = ''.obs;
   String? prefillTitle;
@@ -216,8 +220,18 @@ class SearchMediaController extends GetxController {
       if (season != null && season!.isNotEmpty && season != '0') {
         queryParameters['season'] = season!;
       }
+      final identity = MediaIdentity.parse(mediaSearchKey);
+      final useV3 =
+          searchType == SearchType.media &&
+          identity != null &&
+          await _serverApiVersionService.isV3();
+      if (useV3) {
+        queryParameters['media_source'] = identity.source;
+      }
       final endpoint = switch (searchType) {
-        SearchType.media => '/api/v1/search/media/$mediaSearchKey',
+        SearchType.media => useV3
+            ? '/api/v1/search/media/${identity.id}'
+            : '/api/v1/search/media/$mediaSearchKey',
         SearchType.title => '/api/v1/search/title',
       };
       final response = await _apiClient.get<dynamic>(

--- a/lib/modules/search_result/models/search_result_models.dart
+++ b/lib/modules/search_result/models/search_result_models.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:moviepilot_mobile/modules/recommend/models/recommend_api_item.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 part 'search_result_models.freezed.dart';
 part 'search_result_models.g.dart';
 
@@ -11,8 +12,16 @@ class SearchResultItem with _$SearchResultItem {
     @JsonKey(name: 'torrent_info') SearchTorrentInfo? torrent_info,
   }) = _SearchResultItem;
 
-  factory SearchResultItem.fromJson(Map<String, dynamic> json) =>
-      _$SearchResultItemFromJson(json);
+  factory SearchResultItem.fromJson(Map<String, dynamic> json) {
+    final normalized = Map<String, dynamic>.from(json);
+    final mediaInfo = normalized['media_info'];
+    if (mediaInfo is Map) {
+      normalized['media_info'] = normalizeMediaJson(
+        Map<String, dynamic>.from(mediaInfo),
+      );
+    }
+    return _$SearchResultItemFromJson(normalized);
+  }
 }
 
 @freezed

--- a/lib/modules/subscribe/controllers/subscribe_calendar_controller.dart
+++ b/lib/modules/subscribe/controllers/subscribe_calendar_controller.dart
@@ -4,6 +4,7 @@ import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_calendar_mo
 import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_models.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 
 /// 订阅日历：基于用户 TV 订阅拉取各剧集播出信息，按日期时间轴展示
 class SubscribeCalendarController extends GetxController {
@@ -168,7 +169,7 @@ class SubscribeCalendarController extends GetxController {
     for (final raw in list) {
       if (raw is Map<String, dynamic>) {
         try {
-          final item = SubscribeItem.fromJson(raw);
+          final item = SubscribeItem.fromJson(normalizeSubscribeJson(raw));
           final t = item.type?.trim().toLowerCase() ?? '';
           if (t.contains('电视剧') || t.contains('tv') || t == 'tv') {
             parsed.add(item);

--- a/lib/modules/subscribe/controllers/subscribe_controller.dart
+++ b/lib/modules/subscribe/controllers/subscribe_controller.dart
@@ -10,6 +10,7 @@ import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_submit_resp
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
 import 'package:moviepilot_mobile/services/hive_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:moviepilot_mobile/utils/toast_util.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -193,7 +194,10 @@ class SubscribeController extends GetxController {
       final currentUsernames = await _currentUsernames();
       final parsed = list
           .whereType<Map<String, dynamic>>()
-          .map(SubscribeItem.fromJson)
+          .map(
+            (item) =>
+                SubscribeItem.fromJson(normalizeSubscribeJson(item)),
+          )
           .where(
             (e) => _matchesType(e) && _matchesCurrentUser(e, currentUsernames),
           )

--- a/lib/modules/subscribe/controllers/subscribe_edit_controller.dart
+++ b/lib/modules/subscribe/controllers/subscribe_edit_controller.dart
@@ -15,6 +15,7 @@ import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_media_enums
 import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_models.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:moviepilot_mobile/utils/toast_util.dart';
 
 /// 订阅编辑 Controller
@@ -306,7 +307,7 @@ class SubscribeEditController extends GetxController {
         raw = body['data'] as Map<String, dynamic>? ?? body;
       }
       if (raw != null) {
-        _item = SubscribeItem.fromJson(raw);
+        _item = SubscribeItem.fromJson(normalizeSubscribeJson(raw));
         _initFromItem();
       }
     } catch (e, st) {

--- a/lib/modules/subscribe/controllers/subscribe_history_controller.dart
+++ b/lib/modules/subscribe/controllers/subscribe_history_controller.dart
@@ -4,6 +4,7 @@ import 'package:moviepilot_mobile/modules/multifunction/controllers/multifunctio
 import 'package:moviepilot_mobile/modules/subscribe/controllers/subscribe_controller.dart';
 import 'package:moviepilot_mobile/modules/subscribe/controllers/subscribe_service.dart';
 import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_models.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:moviepilot_mobile/utils/toast_util.dart';
 
 class SubscribeHistoryEntry {
@@ -151,7 +152,7 @@ class SubscribeHistoryController extends GetxController {
       try {
         result.add(
           SubscribeHistoryEntry(
-            item: SubscribeItem.fromJson(raw),
+            item: SubscribeItem.fromJson(normalizeSubscribeJson(raw)),
             raw: raw,
           ),
         );

--- a/lib/modules/subscribe/controllers/subscribe_popular_controller.dart
+++ b/lib/modules/subscribe/controllers/subscribe_popular_controller.dart
@@ -7,6 +7,7 @@ import 'package:moviepilot_mobile/modules/subscribe/controllers/subscribe_contro
 import 'package:moviepilot_mobile/modules/subscribe/defines/subscribe_popular_filter_defines.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 
 class SubscribePopularController extends GetxController {
   final _apiClient = Get.find<ApiClient>();
@@ -118,7 +119,7 @@ class SubscribePopularController extends GetxController {
       for (final raw in list) {
         if (raw is Map<String, dynamic>) {
           try {
-            final item = RecommendApiItem.fromJson(raw);
+            final item = RecommendApiItem.fromJson(normalizeMediaJson(raw));
             parsed.add(item);
           } catch (e, st) {
             _log.handle(e, stackTrace: st, message: '解析热门订阅失败');
@@ -163,7 +164,7 @@ class SubscribePopularController extends GetxController {
       for (final raw in list) {
         if (raw is Map<String, dynamic>) {
           try {
-            final item = RecommendApiItem.fromJson(raw);
+            final item = RecommendApiItem.fromJson(normalizeMediaJson(raw));
             parsed.add(item);
           } catch (e, st) {
             _log.handle(e, stackTrace: st, message: '解析热门订阅失败');
@@ -298,7 +299,7 @@ class SubscribePopularController extends GetxController {
     for (final raw in list) {
       if (raw is Map<String, dynamic>) {
         try {
-          parsed.add(RecommendApiItem.fromJson(raw));
+          parsed.add(RecommendApiItem.fromJson(normalizeMediaJson(raw)));
         } catch (e, st) {
           log.handle(e, stackTrace: st, message: '解析热门订阅失败');
         }

--- a/lib/modules/subscribe/controllers/subscribe_service.dart
+++ b/lib/modules/subscribe/controllers/subscribe_service.dart
@@ -5,6 +5,8 @@ import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_models.dart
 import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_submit_resp.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:moviepilot_mobile/utils/toast_util.dart';
 
 class SubscribeService extends GetxService {
@@ -12,6 +14,8 @@ class SubscribeService extends GetxService {
   final _apiClient = Get.find<ApiClient>();
   final _appService = Get.find<AppService>();
   final _log = Get.find<AppLog>();
+  ServerApiVersionService get _serverApiVersionService =>
+      Get.find<ServerApiVersionService>();
 
   bool _ensureCanSubscribe() {
     if (_appService.canSubscribe) return true;
@@ -44,8 +48,14 @@ class SubscribeService extends GetxService {
     String? title,
   }) async {
     try {
-      final path = '/api/v1/subscribe/media/$mediaKey';
+      final identity = MediaIdentity.parse(mediaKey);
+      final useV3 =
+          identity != null && await _serverApiVersionService.isV3();
+      final path = useV3
+          ? '/api/v1/subscribe/media/${identity.id}'
+          : '/api/v1/subscribe/media/$mediaKey';
       final query = <String, dynamic>{};
+      if (useV3) query['media_source'] = identity.source;
       if (season != null) query['season'] = season;
       if (title != null && title.trim().isNotEmpty) {
         query['title'] = title.trim();
@@ -58,11 +68,10 @@ class SubscribeService extends GetxService {
       if (response.statusCode != 200) return null;
       final data = response.data;
       SubscribeItem? subscribeItem;
-      if (data is Map<String, dynamic>) {
-        subscribeItem = SubscribeItem.fromJson(data);
-      }
       if (data is Map) {
-        subscribeItem = SubscribeItem.fromJson(Map<String, dynamic>.from(data));
+        subscribeItem = SubscribeItem.fromJson(
+          normalizeSubscribeJson(Map<String, dynamic>.from(data)),
+        );
       }
       if (subscribeItem != null && subscribeItem.id != null) {
         return subscribeItem;
@@ -102,6 +111,7 @@ class SubscribeService extends GetxService {
     if (isTv) {
       final ok = await submitTvSubscribe(
         doubanid: doubanid,
+        identityKey: mediaKey,
         name: name,
         season: season,
         year: year,
@@ -111,6 +121,7 @@ class SubscribeService extends GetxService {
     } else {
       final ok = await submitMovieSubscribe(
         doubanid: doubanid,
+        identityKey: mediaKey,
         name: name,
         season: season,
         year: year,
@@ -129,7 +140,8 @@ class SubscribeService extends GetxService {
     }
     try {
       final path = '/api/v1/subscribe/';
-      final response = await _apiClient.post(path, data: payload);
+      final requestPayload = await _prepareSubscribePayload(payload);
+      final response = await _apiClient.post(path, data: requestPayload);
       if (response.statusCode == 200) {
         return SubscribeSubmitResp.fromJson(response.data);
       }
@@ -145,6 +157,7 @@ class SubscribeService extends GetxService {
     int? bestVersion = 0,
     String? doubanid,
     String? episodeGroup = '',
+    String? identityKey,
     String? mediaid = '',
     String? name,
     int? season = 0,
@@ -162,13 +175,29 @@ class SubscribeService extends GetxService {
       'tmdbid': tmdbid,
       'year': year,
     };
+    final isV3 = await _serverApiVersionService.isV3();
+    if (isV3) {
+      final identity = _deriveMediaIdentity(
+        mediaid: identityKey ?? mediaid,
+        tmdbid: tmdbid,
+        doubanid: doubanid,
+        bangumiid: bangumiid,
+      );
+      _removeLegacyIdentityKeys(payload);
+      if (identity != null) {
+        payload['media_source'] = identity.source;
+        payload['media_id'] = identity.id;
+      }
+    }
     final resp = await submitSubscribe('movie', payload: payload);
     return resp;
   }
 
   Future<SubscribeSubmitResp> submitTvSubscribe({
+    String? bangumiid,
     String? doubanid,
     String? episode_group = '',
+    String? identityKey,
     String? mediaid = '',
     String? name,
     int? season = 0,
@@ -189,6 +218,20 @@ class SubscribeService extends GetxService {
       'best_version_full': bestVersionFull,
       'type': '电视剧',
     };
+    final isV3 = await _serverApiVersionService.isV3();
+    if (isV3) {
+      final identity = _deriveMediaIdentity(
+        mediaid: identityKey ?? mediaid,
+        tmdbid: tmdbid,
+        doubanid: doubanid,
+        bangumiid: bangumiid,
+      );
+      _removeLegacyIdentityKeys(payload);
+      if (identity != null) {
+        payload['media_source'] = identity.source;
+        payload['media_id'] = identity.id;
+      }
+    }
     return await submitSubscribe('tv', payload: payload);
   }
 
@@ -197,9 +240,17 @@ class SubscribeService extends GetxService {
     String season = '0',
   }) async {
     if (!_ensureCanSubscribe()) return false;
+    final identity = MediaIdentity.parse(mediaKey);
+    final useV3 =
+        identity != null && await _serverApiVersionService.isV3();
     final response = await _apiClient.delete(
-      '/api/v1/subscribe/media/$mediaKey',
-      queryParameters: {'season': season},
+      useV3
+          ? '/api/v1/subscribe/media/${identity.id}'
+          : '/api/v1/subscribe/media/$mediaKey',
+      queryParameters: {
+        if (useV3) 'media_source': identity.source,
+        'season': season,
+      },
     );
     return response.statusCode == 200 && response.data['success'] == true;
   }
@@ -280,5 +331,68 @@ class SubscribeService extends GetxService {
       throw StateError('返回数据格式错误');
     }
     return SubscribeFilesResult.fromJson(Map<String, dynamic>.from(data));
+  }
+
+  MediaIdentity? _deriveMediaIdentity({
+    String? mediaid,
+    String? tmdbid,
+    String? doubanid,
+    String? bangumiid,
+  }) {
+    final fromMediaId = MediaIdentity.parse(mediaid);
+    if (fromMediaId != null) return fromMediaId;
+    return _identityFromSource('themoviedb', tmdbid) ??
+        _identityFromSource('douban', doubanid) ??
+        _identityFromSource('bangumi', bangumiid);
+  }
+
+  MediaIdentity? _identityFromSource(String source, String? id) {
+    final normalizedId = id?.trim();
+    if (normalizedId == null ||
+        normalizedId.isEmpty ||
+        normalizedId == '0') {
+      return null;
+    }
+    return MediaIdentity(source: source, id: normalizedId);
+  }
+
+  void _removeLegacyIdentityKeys(Map<String, dynamic> payload) {
+    payload.remove('tmdbid');
+    payload.remove('doubanid');
+    payload.remove('bangumiid');
+    payload.remove('mediaid');
+  }
+
+  Future<Map<String, dynamic>> _prepareSubscribePayload(
+    Map<String, dynamic> payload,
+  ) async {
+    if (!await _serverApiVersionService.isV3()) {
+      return payload;
+    }
+
+    final result = Map<String, dynamic>.from(payload);
+    final source = normalizeMediaSource(result['media_source']?.toString());
+    final mediaId = result['media_id']?.toString().trim();
+    final currentIdentity = source != null &&
+            mediaId != null &&
+            mediaId.isNotEmpty &&
+            mediaId != '0'
+        ? MediaIdentity(source: source, id: mediaId)
+        : null;
+    final identity = currentIdentity ??
+        _deriveMediaIdentity(
+          mediaid: result['mediaid']?.toString(),
+          tmdbid: result['tmdbid']?.toString(),
+          doubanid: result['doubanid']?.toString(),
+          bangumiid: result['bangumiid']?.toString(),
+        );
+    _removeLegacyIdentityKeys(result);
+    result.remove('media_source');
+    result.remove('media_id');
+    if (identity != null) {
+      result['media_source'] = identity.source;
+      result['media_id'] = identity.id;
+    }
+    return result;
   }
 }

--- a/lib/modules/subscribe/models/subscribe_files_models.dart
+++ b/lib/modules/subscribe/models/subscribe_files_models.dart
@@ -1,4 +1,5 @@
 import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_models.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 
 class SubscribeFilesResult {
   const SubscribeFilesResult({
@@ -13,7 +14,9 @@ class SubscribeFilesResult {
     final subscribeRaw = json['subscribe'];
     SubscribeItem? subscribe;
     if (subscribeRaw is Map) {
-      subscribe = SubscribeItem.fromJson(Map<String, dynamic>.from(subscribeRaw));
+      subscribe = SubscribeItem.fromJson(
+        normalizeSubscribeJson(Map<String, dynamic>.from(subscribeRaw)),
+      );
     }
 
     final episodesRaw = json['episodes'];

--- a/lib/modules/subtitle/controllers/subtitle_search_controller.dart
+++ b/lib/modules/subtitle/controllers/subtitle_search_controller.dart
@@ -6,12 +6,16 @@ import 'package:moviepilot_mobile/applog/app_log.dart';
 import 'package:moviepilot_mobile/modules/subtitle/models/subtitle_search_models.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 import 'package:moviepilot_mobile/utils/toast_util.dart';
 
 class SubtitleSearchController extends GetxController {
   final _apiClient = Get.find<ApiClient>();
   final _appService = Get.find<AppService>();
   final _log = Get.find<AppLog>();
+  ServerApiVersionService get _serverApiVersionService =>
+      Get.find<ServerApiVersionService>();
 
   var mediaSearchKey = '';
   var mtype = '电影';
@@ -91,9 +95,14 @@ class SubtitleSearchController extends GetxController {
           seasonValue != '0') {
         query['season'] = seasonValue;
       }
+      final identity = MediaIdentity.parse(mediaSearchKey);
+      final useV3 =
+          identity != null && await _serverApiVersionService.isV3();
+      if (useV3) query['media_source'] = identity.source;
+      final requestMediaId = useV3 ? identity.id : mediaSearchKey;
 
       final path =
-          '/api/v1/search/subtitle/media/$mediaSearchKey/stream'
+          '/api/v1/search/subtitle/media/$requestMediaId/stream'
           '?${Uri(queryParameters: query).query}';
 
       final stream = await _apiClient.streamLines(path, token: token);

--- a/lib/modules/user_management/controllers/user_management_controller.dart
+++ b/lib/modules/user_management/controllers/user_management_controller.dart
@@ -5,6 +5,7 @@ import 'package:moviepilot_mobile/modules/profile/models/user_info.dart';
 import 'package:moviepilot_mobile/modules/subscribe/models/subscribe_models.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 
 /// 用户订阅统计
 class UserSubscribeStats {
@@ -186,7 +187,7 @@ class UserManagementController extends GetxController {
       int tvCount = 0;
       for (final item in list) {
         if (item is! Map<String, dynamic>) continue;
-        final sub = SubscribeItem.fromJson(item);
+        final sub = SubscribeItem.fromJson(normalizeSubscribeJson(item));
         final t = sub.type?.trim().toLowerCase() ?? '';
         if (t.contains('电影') || t.contains('movie') || t == 'movie') {
           movieCount++;

--- a/lib/services/server_api_version_service.dart
+++ b/lib/services/server_api_version_service.dart
@@ -1,0 +1,66 @@
+import 'package:get/get.dart';
+import 'package:moviepilot_mobile/services/api_client.dart';
+
+class ServerApiVersionService extends GetxService {
+  final _apiClient = Get.find<ApiClient>();
+  final _cache = <String, bool>{};
+  final _inFlight = <String, Future<bool>>{};
+  int _generation = 0;
+
+  Future<bool> isV3() {
+    final baseUrl = _normalizeBaseUrl(_apiClient.baseUrl);
+    if (baseUrl == null) return Future.value(false);
+    final cached = _cache[baseUrl];
+    if (cached != null) return Future.value(cached);
+    final pending = _inFlight[baseUrl];
+    if (pending != null) return pending;
+
+    final generation = _generation;
+    final detection = _detect(baseUrl, generation);
+    _inFlight[baseUrl] = detection;
+    return detection;
+  }
+
+  Future<bool> _detect(String baseUrl, int generation) async {
+    try {
+      final response = await _apiClient.get<dynamic>('/api/v1/media/source');
+      final result = response.statusCode == 200 && response.data is List;
+      if (generation == _generation) {
+        _cache[baseUrl] = result;
+      }
+      return result;
+    } catch (_) {
+      return false;
+    } finally {
+      if (generation == _generation) {
+        _inFlight.remove(baseUrl);
+      }
+    }
+  }
+
+  void markV3(String? baseUrl, bool isV3) {
+    final key = _normalizeBaseUrl(baseUrl ?? _apiClient.baseUrl);
+    if (key == null) return;
+    _cache[key] = isV3;
+    _inFlight.remove(key);
+  }
+
+  void reset() {
+    _generation++;
+    _cache.clear();
+    _inFlight.clear();
+  }
+
+  void invalidate(String? baseUrl) {
+    final key = _normalizeBaseUrl(baseUrl ?? _apiClient.baseUrl);
+    if (key == null) return;
+    _generation++;
+    _cache.remove(key);
+    _inFlight.clear();
+  }
+
+  String? _normalizeBaseUrl(String? baseUrl) {
+    final normalized = baseUrl?.trim();
+    return normalized == null || normalized.isEmpty ? null : normalized;
+  }
+}

--- a/lib/utils/http_path_builder_util.dart
+++ b/lib/utils/http_path_builder_util.dart
@@ -1,5 +1,6 @@
 import 'package:moviepilot_mobile/modules/discover/controllers/discover_controller.dart';
 import 'package:moviepilot_mobile/modules/recommend/models/recommend_api_item.dart';
+import 'package:moviepilot_mobile/utils/media_identity_util.dart';
 
 class HttpPathBuilderUtil {
   static String buildHttpPath(DiscoverSource source, String mediaId) {
@@ -19,7 +20,10 @@ class HttpPathBuilderUtil {
   }
 
   static String buildMediaPath(RecommendApiItem item) {
-    final prefix = item.mediaid_prefix;
+    final storedPrefix = item.mediaid_prefix;
+    final prefix = storedPrefix != null && storedPrefix.isNotEmpty
+        ? storedPrefix
+        : legacyPrefixOf(normalizeMediaSource(item.source));
     final mediaId = item.media_id;
     if (prefix != null &&
         prefix.isNotEmpty &&

--- a/lib/utils/media_identity_util.dart
+++ b/lib/utils/media_identity_util.dart
@@ -1,0 +1,149 @@
+String? normalizeMediaSource(String? raw) {
+  final normalized = raw?.trim().toLowerCase();
+  if (normalized == null || normalized.isEmpty) return null;
+  switch (normalized) {
+    case 'tmdb':
+    case 'themoviedb':
+      return 'themoviedb';
+    case 'douban':
+      return 'douban';
+    case 'bangumi':
+      return 'bangumi';
+    case 'anilist':
+      return 'anilist';
+    case 'imdb':
+      return 'imdb';
+    case 'tvdb':
+      return 'tvdb';
+    default:
+      return normalized;
+  }
+}
+
+String? legacyPrefixOf(String? source) {
+  final normalized = normalizeMediaSource(source);
+  if (normalized == null) return null;
+  return normalized == 'themoviedb' ? 'tmdb' : normalized;
+}
+
+class MediaIdentity {
+  const MediaIdentity({required this.source, required this.id});
+
+  final String source;
+  final String id;
+
+  static MediaIdentity? parse(String? key) {
+    final trimmed = key?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+    final separator = trimmed.indexOf(':');
+    if (separator <= 0) return null;
+    final source = normalizeMediaSource(trimmed.substring(0, separator));
+    final id = trimmed.substring(separator + 1).trim();
+    if (source == null || id.isEmpty || id == '0') return null;
+    return MediaIdentity(source: source, id: id);
+  }
+
+  String get legacyKey => '${legacyPrefixOf(source)}:$id';
+}
+
+Map<String, dynamic> normalizeMediaJson(Map<String, dynamic> json) {
+  final result = Map<String, dynamic>.from(json);
+  final source = _nonEmptyText(result['source']);
+  final mediaSource = _nonEmptyText(result['media_source']);
+
+  if (source == null && mediaSource != null) {
+    result['source'] = mediaSource;
+  } else if (source != null && mediaSource == null) {
+    result['media_source'] = source;
+  }
+
+  final normalizedSource = normalizeMediaSource(
+    _nonEmptyText(result['source']) ?? _nonEmptyText(result['media_source']),
+  );
+  if (!_hasValue(result['media_id'])) {
+    final fallbackKey = switch (normalizedSource) {
+      'themoviedb' => 'tmdb_id',
+      'douban' => 'douban_id',
+      'bangumi' => 'bangumi_id',
+      'tvdb' => 'tvdb_id',
+      'imdb' => 'imdb_id',
+      _ => null,
+    };
+    if (fallbackKey != null && _hasIdentityValue(result[fallbackKey])) {
+      result['media_id'] = result[fallbackKey].toString().trim();
+    }
+  }
+
+  if (!_hasValue(result['mediaid_prefix'])) {
+    final sourcePrefix = legacyPrefixOf(normalizedSource);
+    if (sourcePrefix != null) {
+      result['mediaid_prefix'] = sourcePrefix;
+    } else if (_hasIdentityValue(result['tmdb_id'])) {
+      result['mediaid_prefix'] = 'tmdb';
+    } else if (_hasIdentityValue(result['douban_id'])) {
+      result['mediaid_prefix'] = 'douban';
+    } else if (_hasIdentityValue(result['bangumi_id'])) {
+      result['mediaid_prefix'] = 'bangumi';
+    }
+  }
+
+  return result;
+}
+
+Map<String, dynamic> normalizeSubscribeJson(Map<String, dynamic> json) {
+  final result = Map<String, dynamic>.from(json);
+  final source = normalizeMediaSource(_nonEmptyText(result['media_source']));
+  final mediaId = result['media_id'];
+  if (source == null || !_hasValue(mediaId)) return result;
+
+  final legacyIdKey = switch (source) {
+    'themoviedb' => 'tmdbid',
+    'douban' => 'doubanid',
+    'bangumi' => 'bangumiid',
+    _ => null,
+  };
+  if (legacyIdKey != null && !_hasValue(result[legacyIdKey])) {
+    result[legacyIdKey] = mediaId;
+  }
+  if (!_hasValue(result['mediaid'])) {
+    final prefix = legacyPrefixOf(source);
+    if (prefix != null) {
+      result['mediaid'] = '$prefix:${mediaId.toString().trim()}';
+    }
+  }
+  return result;
+}
+
+Map<String, dynamic> sanitizeMediaIdentityPayload(
+  Map<String, dynamic> json,
+) {
+  final result = Map<String, dynamic>.from(json);
+  final source = normalizeMediaSource(
+    _nonEmptyText(result['media_source']) ?? _nonEmptyText(result['source']),
+  );
+  final mediaId = result['media_id'];
+  if (source == null || !_hasValue(mediaId)) {
+    result.remove('media_source');
+    result.remove('media_id');
+    return result;
+  }
+
+  result['media_source'] = source;
+  if (mediaId is String) {
+    result['media_id'] = mediaId.trim();
+  }
+  return result;
+}
+
+String? _nonEmptyText(Object? value) {
+  if (value == null) return null;
+  final text = value.toString().trim();
+  return text.isEmpty ? null : text;
+}
+
+bool _hasValue(Object? value) => _nonEmptyText(value) != null;
+
+bool _hasIdentityValue(Object? value) {
+  final text = _nonEmptyText(value);
+  return text != null && text != '0';
+}


### PR DESCRIPTION
## 现象

在 MoviePilot **v3** 服务端上，点进任意影片详情页立即报：

> 请求失败 (422)：请求参数不正确

## 根因

v3 对「媒体身份」做了破坏性重构：原来带前缀的复合 ID（`tmdb:550`）被拆成
`media_source`（数据源规范值）+ `media_id`（该来源的原生 ID）两个独立参数。

- v2：`GET /api/v1/media/tmdb:550?type_name=电影`
- v3：`GET /api/v1/media/550?media_source=themoviedb&type_name=电影`
  —— `media_source` 是 **required query**，缺失即 FastAPI 422

同时 v3 的媒体响应体里 `source` 改名为 `media_source`（取值也从 `tmdb` 变成 `themoviedb`）、
`mediaid_prefix` 被删除。App 的 `HttpPathBuilderUtil.buildMediaPath` 正是靠
`mediaid_prefix` + `media_id` 拼出 `tmdb:550`，在 v3 下回落到 `tmdb_id` 仍然拼出同样的复合 ID
打给详情接口，于是 422。

## 受影响的接口

对比 v2 与 v3 的 `openapi.json`，共有 **7 个非插件端点新增了必填 query `media_source`**，
全部在详情页链路上：

| 端点 | App 里的场景 |
|---|---|
| `GET /api/v1/media/{media_id}` | 媒体详情（本 issue 的直接现象） |
| `GET /api/v1/subscribe/media/{media_id}` | 详情页订阅状态 |
| `DELETE /api/v1/subscribe/media/{media_id}` | 取消订阅 |
| `GET /api/v1/search/media/{media_id}` | 详情页「搜索资源」 |
| `GET /api/v1/search/media/{media_id}/stream` | 同上（流式） |
| `GET /api/v1/search/subtitle/media/{media_id}` | 详情页「字幕搜索」 |
| `GET /api/v1/search/subtitle/media/{media_id}/stream` | 同上（流式） |

另有一批不报 422 但语义已变的：

- `GET /api/v1/media/seasons`：`mediaid` → `media_source` + `media_id`
- `GET /api/v1/mediaserver/exists`：`tmdbid` → `media_source` + `media_id`
- `POST /api/v1/mediaserver/notexists`：body 里 `media_source` / `media_id` 必须成对，半对会 422
- `POST /api/v1/subscribe/`：`Subscribe` schema 删除了 `tmdbid` / `doubanid` / `bangumiid` / `mediaid`，
  改为 `media_source` + `media_id`
- 订阅响应体同样不再返回 `tmdbid` 等旧字段，导致订阅页点进详情拿不到媒体标识

## 方案

**双兼容，不硬切 v3**（现存大量用户仍在 v2）：

1. 新增 `lib/utils/media_identity_util.dart`：来源别名归一（`tmdb` ↔ `themoviedb`）、
   复合 key 解析（只按第一个冒号切分，保留原生 ID 自身可能带的冒号）、
   以及三个 JSON 规范化函数。
2. 新增 `lib/services/server_api_version_service.dart`：用 v3 独有的
   `GET /api/v1/media/source`（v2 返回 404）探测服务端版本，按 baseUrl 缓存、并发去重，
   登录/切换账号时失效重探。
3. App 内部**继续**使用 `tmdb:550` 作为路由参数与 Hive 缓存键 —— 路由协议、缓存结构零变更，
   只在发请求前按服务端版本决定拆不拆。详情接口另加一次 422 兜底重试（反向形态重发一次并回写探测结果），
   万一探测判断失误也不会白屏。
4. **不新增 freezed 字段、不跑 build_runner**（仓库 `AGENTS.md` 已注明
   `form_block_models.freezed.dart` 有已知生成问题，不能全量 regenerate）。
   改为在 `fromJson` 之前对原始 JSON 做一次「v3 → v2 字段名」规范化：
   把 `media_source` 补成 `source`、按来源推出 `mediaid_prefix`、必要时从辅助 ID 回填 `media_id`；
   订阅响应则把 `media_source` + `media_id` 映射回 `tmdbid` / `doubanid` / `bangumiid` / `mediaid`。
   于是现有全部下游逻辑（含 `HttpPathBuilderUtil` 与订阅页跳详情）原样继续工作。

全部 20 个 `MediaDetail.fromJson` / `RecommendApiItem.fromJson` / `SubscribeItem.fromJson`
调用点都已接上对应的规范化函数（含 Hive 缓存回读）。

## v2 行为

v2 分支上发出的 path、query、body 与改动前逐字一致；
所有版本相关分支的判定条件都是「能解析出媒体身份 **且** 探测到 v3」，
任一不满足即回落到原有代码路径。

## 验证

- `flutter analyze`：0 error，本次改动涉及的文件 0 warning / 0 info
- v3 契约来自真实 v3 服务端的 `openapi.json` 与 `jxxghp/MoviePilot` 仓库 `v3` 分支源码
  （线上 https://api.movie-pilot.org 的 Swagger 目前仍是 v2 文档：`/media/seasons` 还是 `mediaid`、
  也没有 `/media/source`，所以没有以它为准）
- 受限于没有 v2/v3 两套实机环境，未做端到端手测，烦请按实际环境验一下

🤖 Generated with [Claude Code](https://claude.com/claude-code)
