### PR TITLE
fix: 适配 MoviePilot v3 的统一响应 envelope 与扁平搜索结果

### DIFF
--- a/lib/modules/agent/repositories/agent_repository.dart
+++ b/lib/modules/agent/repositories/agent_repository.dart
@@ -29,13 +29,20 @@ class AgentRepository implements AgentRepositoryContract {
     int page = 1,
     int count = 30,
   }) async {
-    final response = await _apiClient.get<Map<String, dynamic>>(
+    final response = await _apiClient.get<dynamic>(
       '/api/v1/message/agent/sessions',
       queryParameters: {'page': page, 'count': count},
     );
     final data = response.data;
-    if (data == null || data['success'] != true) {
-      throw StateError(data?['message']?.toString() ?? '会话列表加载失败');
+    if (data is List) {
+      return data
+          .whereType<Map>()
+          .map((item) => AgentSession.fromJson(Map<String, dynamic>.from(item)))
+          .toList(growable: false);
+    }
+    if (data is! Map || data['success'] != true) {
+      final message = data is Map ? data['message']?.toString() : null;
+      throw StateError(message ?? '会话列表加载失败');
     }
     final list = data['data'];
     if (list is! List) return const [];

--- a/lib/modules/dashboard/controllers/dashboard_controller.dart
+++ b/lib/modules/dashboard/controllers/dashboard_controller.dart
@@ -422,14 +422,19 @@ class DashboardController extends GetxController {
   Future<void> loadMemoryData() async {
     try {
       talker.info('开始加载内存数据');
-      final response = await apiClient.get<List<dynamic>>(
-        '/api/v1/dashboard/memory',
-      );
+      final response = await apiClient.get<dynamic>('/api/v1/dashboard/memory');
       if (response.statusCode == 200) {
         final data = response.data!;
-        if (data.length >= 2) {
-          final memoryUsed = data[0] as int;
-          final memoryUsage = data[1] as int;
+        int? memoryUsed;
+        int? memoryUsage;
+        if (data is Map) {
+          memoryUsed = (data['used'] as num?)?.toInt();
+          memoryUsage = (data['usage'] as num?)?.round();
+        } else if (data is List && data.length >= 2) {
+          memoryUsed = (data[0] as num?)?.toInt();
+          memoryUsage = (data[1] as num?)?.round();
+        }
+        if (memoryUsed != null && memoryUsage != null) {
           memoryData.value = [memoryUsed, memoryUsage];
           _appendMemoryChartData(memoryUsage.toDouble());
           talker.info('内存数据加载成功: 使用 $memoryUsed 字节, 使用率 $memoryUsage%');

--- a/lib/modules/site/controllers/site_detail_controller.dart
+++ b/lib/modules/site/controllers/site_detail_controller.dart
@@ -135,17 +135,28 @@ class SiteDetailController extends GetxController {
         return;
       }
       final raw = response.data;
-      if (raw is! Map<String, dynamic>) {
+      final List<SiteUserDataHistoryItem> list;
+      if (raw is List) {
+        list = raw
+            .whereType<Map>()
+            .map(
+              (item) => SiteUserDataHistoryItem.fromJson(
+                Map<String, dynamic>.from(item),
+              ),
+            )
+            .toList();
+      } else if (raw is Map<String, dynamic>) {
+        final res = SiteUserDataHistoryResponse.fromJson(raw);
+        if (!res.success) {
+          errorText.value = res.message ?? '请求失败';
+          historyItems.clear();
+          return;
+        }
+        list = res.data.toList();
+      } else {
         historyItems.clear();
         return;
       }
-      final res = SiteUserDataHistoryResponse.fromJson(raw);
-      if (!res.success) {
-        errorText.value = res.message ?? '请求失败';
-        historyItems.clear();
-        return;
-      }
-      final list = res.data.toList();
       list.sort((a, b) {
         final da = a.updatedDay;
         final db = b.updatedDay;

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -8,6 +8,7 @@ import 'package:moviepilot_mobile/applog/app_log.dart';
 import 'package:talker/talker.dart';
 import 'package:talker_dio_logger/talker_dio_logger.dart';
 import 'package:moviepilot_mobile/services/app_service.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
 import 'package:moviepilot_mobile/utils/dio_adapter_config_stub.dart'
     if (dart.library.io) 'package:moviepilot_mobile/utils/dio_adapter_config_io.dart'
     if (dart.library.js_interop) 'package:moviepilot_mobile/utils/dio_adapter_config_web.dart';
@@ -41,6 +42,8 @@ class ApiHttpException implements Exception {
 }
 
 class ApiClient extends g.GetxController {
+  static const _skipV3EnvelopeUnwrapKey = 'skipV3EnvelopeUnwrap';
+
   final _appService = g.Get.find<AppService>();
   final _iosSharedSessionService = g.Get.find<IosSharedSessionService>();
   final _hiveService = g.Get.find<HiveService>();
@@ -191,6 +194,59 @@ class ApiClient extends g.GetxController {
         ),
       );
     }
+    _dio.interceptors.add(
+      InterceptorsWrapper(
+        onResponse: (response, handler) async {
+          if (response.requestOptions.extra[_skipV3EnvelopeUnwrapKey] == true ||
+              response.requestOptions.responseType != ResponseType.json) {
+            handler.next(response);
+            return;
+          }
+
+          final envelope = response.data;
+          if (envelope is! Map ||
+              envelope['success'] is! bool ||
+              !envelope.containsKey('data')) {
+            handler.next(response);
+            return;
+          }
+
+          if (!g.Get.isRegistered<ServerApiVersionService>()) {
+            handler.next(response);
+            return;
+          }
+
+          try {
+            final isV3 = await g.Get.find<ServerApiVersionService>().isV3();
+            if (!isV3) {
+              handler.next(response);
+              return;
+            }
+          } catch (_) {
+            handler.next(response);
+            return;
+          }
+
+          final data = envelope['data'];
+          if (data == null) {
+            handler.next(response);
+            return;
+          }
+          if (data is Map) {
+            // 业务字段优先：仅在原始数据没有同名键时才补 envelope 的字段，
+            // 避免把接口本身返回的 success / message / data 覆盖掉。
+            final merged = Map<String, dynamic>.from(data);
+            merged.putIfAbsent('success', () => envelope['success']);
+            merged.putIfAbsent('message', () => envelope['message']);
+            merged.putIfAbsent('data', () => data);
+            response.data = merged;
+          } else {
+            response.data = data;
+          }
+          handler.next(response);
+        },
+      ),
+    );
   }
 
   Future<void> _ensureReady() => _ready;
@@ -531,6 +587,7 @@ class ApiClient extends g.GetxController {
     int? timeout,
     Map<String, dynamic>? headers,
     bool skipUnauthorizedHandling = false,
+    bool skipV3EnvelopeUnwrap = false,
   }) async {
     await _ensureReady();
     final authToken = token ?? this.token;
@@ -546,7 +603,10 @@ class ApiClient extends g.GetxController {
         // 允许所有状态码，让调用者自己处理错误
         return true;
       },
-      extra: {if (skipUnauthorizedHandling) 'skipUnauthorizedHandling': true},
+      extra: {
+        if (skipUnauthorizedHandling) 'skipUnauthorizedHandling': true,
+        if (skipV3EnvelopeUnwrap) _skipV3EnvelopeUnwrapKey: true,
+      },
     );
     final response = await _dio.get<T>(
       path,

--- a/lib/services/server_api_version_service.dart
+++ b/lib/services/server_api_version_service.dart
@@ -23,8 +23,15 @@ class ServerApiVersionService extends GetxService {
 
   Future<bool> _detect(String baseUrl, int generation) async {
     try {
-      final response = await _apiClient.get<dynamic>('/api/v1/media/source');
-      final result = response.statusCode == 200 && response.data is List;
+      final response = await _apiClient.get<dynamic>(
+        '/api/v1/media/source',
+        skipV3EnvelopeUnwrap: true,
+      );
+      final data = response.data;
+      final hasSourceList =
+          data is List ||
+          (data is Map && data.containsKey('data') && data['data'] is List);
+      final result = response.statusCode == 200 && hasSourceList;
       if (generation == _generation) {
         _cache[baseUrl] = result;
       }


### PR DESCRIPTION
接 #97。#97 修好了媒体身份契约，但用户在真实 v3 上实测仍然：**详情页 422、仪表盘所有数值显示 0**。
根因是另一个 #97 完全没覆盖的破坏性变更。

## 根因

v3 用 `ResponseAPIRouter` 把几乎所有 JSON 响应统一包装成 envelope：

```json
{"success": true, "message": "", "data": <原来的裸响应>}
```

对比 v2 与 v3 的 `openapi.json`，**266 个端点**从裸响应变成了 envelope。实测（携带合法 token）：

```
GET /api/v1/dashboard/cpu      → {"success":true,"message":"","data":7.1}
GET /api/v1/dashboard/network  → {"success":true,"message":"","data":[43885,44009]}
GET /api/v1/media/source       → {"success":true,"message":"","data":[{...}]}
GET /api/v1/media/550?media_source=themoviedb&type_name=电影
                               → {"success":true,"message":"","data":{"title":"搏击俱乐部",...}}
```

网页端正常，是因为前端 `src/api/client.ts` 里有统一的 envelope 拦截器；App 没有这一层。

两个现象由此而来：

1. **仪表盘全 0** —— `dashboard/*` 在 v2 返回裸 float / 裸 List / 裸对象，App 把 Map 当数值解析，全部回落默认值。
2. **详情页仍 422** —— #97 的版本探测判据是「`/api/v1/media/source` 返回 200 **且 body 是 List**」，
   而这个探测端点自身也被包成了 envelope（Map），判据永不成立 → 探测回落 v2 → 继续按 v2 形态请求详情。

## 改动

只有 5 个文件，解包逻辑集中在 `ApiClient` 的一处拦截器里，业务层零散落：

| `data` 类型 | 处理 | 原因 |
|---|---|---|
| `null` | 保持原 envelope | 操作型接口（`Response_NoneType_`），现有代码正是读 `success` 判断成败 |
| `Map` | 合并原始字段，再 `putIfAbsent` 补 `success` / `message` / `data` | 让期待裸对象、读 `success`、读 `data.id` 三类调用方同时可用；业务同名字段优先，不被 envelope 覆盖 |
| `List` | 解包成裸 List | 期待裸列表的调用方占绝大多数 |
| 标量 | 解包 | 例如 `dashboard/cpu` 的 `7.1` |

- **仅在探测到 v3 时介入**，v2 全程不解包，行为零变更。
- 版本探测请求带 `skipV3EnvelopeUnwrap` 标记跳过解包（避免自我递归），判据放宽为「200 且能取到来源列表」。
- 用 openapi 交叉核对了全部读 `success` 的调用点，修正三处「v3 返回 List 而代码读 `success`」的：
  `message/agent/sessions`、`site/userdata/{site_id}`、`dashboard/memory`（v3 由 `[used, usage]` 变为对象），
  均改为兼容两种形态。

## 验证

`flutter analyze`：0 error，改动文件无新增 warning。

另外写了一个联机集成测试，直接打真实 v3 服务端，用 App 自己的解析链路（`normalizeMediaJson` +
`MediaDetail.fromJson` + `StatisticModel` + `SubscribeItem` + `HttpPathBuilderUtil`）逐项断言，
**10 项全部通过**：

```
详情 OK: 绿灯军团 (2026) seasons=1 prefix=tmdb
统计 OK: movie=1996 tv=310 episode=10207
CPU OK: 7.9  网络 OK: [24621, 24885]
订阅 OK: 无敌少侠 tmdbid=95557 mediaid=tmdb:95557
推荐项 path OK: douban:38581618
旧形态对照 OK: 422 {success: false, message: 请求参数不正确,
                   data: [{location: [query, media_source], message: Field required}]}
```

最后一条是回归对照：旧形态请求确实仍返回 422，证明 v3 分支走的是新形态。

测试文件是临时联机验证用的（依赖真实服务端与 token），没有包含在这个 PR 里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 追加：v3 实时搜索返回的是扁平种子结构（「未知标题」「未知时间」）

用户实测反馈：搜索资源时结果列表每一条都显示「未知标题」「未知时间」。

v3 把实时搜索接口的响应体从 Context 列表改成了 TorrentInfo 列表：

| 接口 | v2 | v3 |
|---|---|---|
| `GET /api/v1/search/title` | `Response`（data 为 Context 列表） | `Response_list_TorrentInfo__` |
| `GET /api/v1/search/media/{media_id}` | `Response`（data 为 Context 列表） | `Response_list_TorrentInfo__` |
| `GET /api/v1/search/last` | Context 列表 | `Response_List_Context__`（**未变**） |

`SearchResultItem` 是按 Context 的 `meta_info` / `media_info` / `torrent_info` 三层结构解析的，
v3 实时搜索结果里这层外壳没有了，于是标题、发布时间、大小、站点全部取不到。

修法是在 `SearchResultItem.fromJson` 里补一层形态兼容：当 json 同时缺少这三个键时，
说明它本身就是一条种子信息，包装成 `{'torrent_info': json}` 再交给原有解析链路。
v2 的响应以及 v3 的 `/search/last` 都带有这三个键，不会走到该分支，行为不变。

`_displayTitle` 原本就有 `item.torrent_info?.title` 的兜底，包装后标题、时间即可正常显示。
