### PR TITLE
fix: 修复 v3 下搜索结果显示「未知标题」（服务端 response_model 错误的客户端兜底）

### DIFF
--- a/lib/modules/search/controllers/search_controller.dart
+++ b/lib/modules/search/controllers/search_controller.dart
@@ -250,7 +250,15 @@ class SearchMediaController extends GetxController {
       }
 
       final raw = response.data;
-      final list = _extractList(raw);
+      var list = _extractList(raw).toList();
+      // v3 的 /search/media 与 /search/title 声明了 list[TorrentInfo] 的 response_model，
+      // 而链路实际返回 Context，字段对不上会被序列化成一批空壳；
+      // 这种情况下回退到 /search/last 取同一次搜索缓存下来的完整结果。
+      if (_looksStrippedResult(list) &&
+          await _serverApiVersionService.isV3()) {
+        final fallback = await _fetchLastSearchResults(token);
+        if (fallback.isNotEmpty) list = fallback;
+      }
       items
         ..clear()
         ..addAll(
@@ -472,6 +480,35 @@ class SearchMediaController extends GetxController {
       if (matchedDirection.isNotEmpty) {
         sortDirection.value = matchedDirection.first;
       }
+    }
+  }
+
+  /// 判断搜索结果是否被服务端序列化成了空壳：既没有 Context 的三层结构，
+  /// 也没有种子标题，说明这批数据没有可用信息。
+  bool _looksStrippedResult(List<dynamic> list) {
+    if (list.isEmpty) return false;
+    for (final item in list) {
+      if (item is! Map) return false;
+      if (item['torrent_info'] != null) return false;
+      if (item['meta_info'] != null) return false;
+      final title = item['title'];
+      if (title is String && title.trim().isNotEmpty) return false;
+    }
+    return true;
+  }
+
+  /// 回退获取上次搜索结果（/search/last 返回完整的 Context 列表）。
+  Future<List<dynamic>> _fetchLastSearchResults(String? token) async {
+    try {
+      final response = await _apiClient.get<dynamic>(
+        '/api/v1/search/last',
+        token: token,
+      );
+      if ((response.statusCode ?? 0) != 200) return const [];
+      return _extractList(response.data).toList();
+    } catch (e, st) {
+      _log.handle(e, stackTrace: st, message: '回退获取上次搜索结果失败');
+      return const [];
     }
   }
 

--- a/lib/modules/search_result/models/search_result_models.dart
+++ b/lib/modules/search_result/models/search_result_models.dart
@@ -13,7 +13,15 @@ class SearchResultItem with _$SearchResultItem {
   }) = _SearchResultItem;
 
   factory SearchResultItem.fromJson(Map<String, dynamic> json) {
-    final normalized = Map<String, dynamic>.from(json);
+    var normalized = Map<String, dynamic>.from(json);
+    // v3 的实时搜索接口（/search/media/{media_id}、/search/title）直接返回种子信息，
+    // 不再包一层 Context；这里补回 App 内部使用的 meta_info / media_info / torrent_info 结构。
+    // v2 以及 v3 的 /search/last 仍返回 Context，带这三个键，不会走到这个分支。
+    if (!normalized.containsKey('torrent_info') &&
+        !normalized.containsKey('meta_info') &&
+        !normalized.containsKey('media_info')) {
+      normalized = <String, dynamic>{'torrent_info': normalized};
+    }
     final mediaInfo = normalized['media_info'];
     if (mediaInfo is Map) {
       normalized['media_info'] = normalizeMediaJson(


### PR DESCRIPTION
用户在 v3 上实测：搜索资源时结果列表每一条都显示「未知标题」「未知时间」。

## 根因：服务端 response_model 与实际返回类型不符

**这个问题的根在 MoviePilot 服务端，不在 App。** 对真实 v3 服务端实测（单站点搜索）：

```
GET /api/v1/search/title?keyword=阿凡达&sites=4   → HTTP 200，13 条结果
元素顶层键: site, site_name, title, media_source, media_id, enclosure, size ...
title: null   site_name: null   size: 0   pubdate: null   seeders: 0
有 title 的条目：0 / 13
```

13 条全是空壳。原因在 `app/api/endpoints/search.py`：

```python
@router.get("/title", response_model=_SchemaResponse[list[_SchemaTorrentInfo]])
async def search_by_title(...):
    torrents = await SearchChain().async_search_by_title(...)   # -> List[Context]
    return _SchemaResponse(success=True, data=[torrent.to_dict() for torrent in torrents])
```

而 `app/chain/search/title.py` 里 `async_search_by_title(...) -> List[Context]`。
`Context.to_dict()` 产出 `{meta_info, media_info, torrent_info}` 三层结构，与 `TorrentInfo`
的字段完全对不上，被 pydantic 按 response_model 序列化后**全部变成 null**。

`GET /search/media/{media_id}` 同样：`async_search_by_id` 也返回 `List[Context]`，
response_model 同样写的 `list[TorrentInfo]`。所以详情页「搜索资源」和标题搜索一起坏。

MP 网页端不受影响，是因为它走的是 SSE 流式端点（`response_model=None`，不过 pydantic 过滤）。

## App 侧的自救

`/api/v1/search/last` 的 response_model 声明为 `Response[List[Context]]`，是正确的。
同一次搜索通过它取回的数据完整：

```
torrent_info.title: Avatar Fire and Ash 2025 UHD BluRay 2160p x265 10bit DV HDR TrueHD7.1 Atmos ...
torrent_info.site_name: 朋友 | size: 41596758262 | pubdate: 2026-08-19 03:39:05
meta_info.name: Avatar Fire And Ash
```

所以本 PR 做两层兼容：

1. **`SearchResultItem.fromJson` 形态兼容**：当 json 同时缺少 `torrent_info` / `meta_info` /
   `media_info` 三个键时，说明它本身就是一条种子信息，包装成 `{'torrent_info': json}`
   再交给原有解析链路。这是为将来服务端真的改成扁平结构准备的，v2 与 `/search/last` 都带这三个键，不会走到该分支。

2. **空壳回退**：v3 下若搜索结果整批既没有 Context 三层结构、也没有种子标题，判定为被服务端洗空，
   回退调用 `/search/last` 取同一次搜索缓存下来的完整结果。服务端修正 response_model 之后，
   返回值会直接可用，回退分支不再触发；判定条件里要求 `isV3()`，v2 完全不受影响。

## 验证

- `flutter analyze`：0 error，改动文件未新增 warning/info
- 上述服务端行为、`/search/last` 的完整数据，均在真实 v3 实例上实测

## 建议

根治还是要在 MoviePilot 侧把那两处 `response_model` 改成 `_SchemaResponse[List[_SchemaContext]]`，
与 `/search/last` 保持一致。本 PR 是客户端侧的兜底，让用户不必等服务端发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
