### PR TITLE
fix: 清理 v3 下已失效的旧媒体 ID 字段与消失的存储用量端点

### DIFF
--- a/lib/modules/download/controllers/download_controller.dart
+++ b/lib/modules/download/controllers/download_controller.dart
@@ -17,6 +17,7 @@ import 'package:moviepilot_mobile/modules/search_result/models/search_result_mod
 import 'package:moviepilot_mobile/modules/setting/controllers/setting_controller.dart';
 import 'package:moviepilot_mobile/modules/setting/models/setting_models.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
 import 'package:moviepilot_mobile/utils/toast_util.dart';
 import 'package:moviepilot_mobile/utils/prefs_keys.dart';
 import 'package:path_provider/path_provider.dart';
@@ -27,6 +28,8 @@ class DownloadController extends GetxController {
 
   final _apiClient = Get.find<ApiClient>();
   final _log = Get.find<AppLog>();
+  ServerApiVersionService get _serverApiVersionService =>
+      Get.find<ServerApiVersionService>();
   final scrollController = DraggableScrollableController();
   // 下载器列表（使用 DownloadClient）
   final downloaders = <DownloadClient>[].obs;
@@ -419,13 +422,13 @@ class DownloadController extends GetxController {
     return normalized;
   }
 
-  ({String path, Map<String, dynamic> body}) _buildDownloadRequest({
+  Future<({String path, Map<String, dynamic> body})> _buildDownloadRequest({
     required Map<String, dynamic> torrentIn,
     required Map<String, dynamic>? mediaIn,
     required String downloader,
     required String? savePath,
     String? customTmdbId,
-  }) {
+  }) async {
     final body = <String, dynamic>{
       'torrent_in': torrentIn,
       'downloader': downloader,
@@ -439,9 +442,16 @@ class DownloadController extends GetxController {
       _printDownload('_buildDownloadRequest: use POST / (has media_in)');
       return (path: '/api/v1/download/', body: body);
     }
-    if (parsedTmdb != null) body['tmdbid'] = parsedTmdb;
+    if (parsedTmdb != null) {
+      if (await _serverApiVersionService.isV3()) {
+        body['media_source'] = 'themoviedb';
+        body['media_id'] = parsedTmdb.toString();
+      } else {
+        body['tmdbid'] = parsedTmdb;
+      }
+    }
     _printDownload(
-      '_buildDownloadRequest: use POST /add (no media_in, tmdbid=$parsedTmdb)',
+      '_buildDownloadRequest: use POST /add (no media_in, mediaId=$parsedTmdb)',
     );
     return (path: '/api/v1/download/add', body: body);
   }
@@ -616,7 +626,7 @@ class DownloadController extends GetxController {
     isDownloading.value = true;
     try {
       final mediaIn = _buildDownloadMediaIn(item, customTmdbId: customTmdbId);
-      final request = _buildDownloadRequest(
+      final request = await _buildDownloadRequest(
         torrentIn: torrentIn,
         mediaIn: mediaIn,
         downloader: selectedDownloader.value!.name,

--- a/lib/modules/file_manager/controllers/file_manager_browser_controller.dart
+++ b/lib/modules/file_manager/controllers/file_manager_browser_controller.dart
@@ -8,6 +8,7 @@ import 'package:moviepilot_mobile/modules/media_organize/models/media_organize_m
 import 'package:moviepilot_mobile/modules/recognize/models/recognize_model.dart';
 import 'package:moviepilot_mobile/modules/storage/controllers/storage_list_controller.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
 
 class FileActionResult {
   const FileActionResult({required this.success, this.message = ''});
@@ -20,6 +21,8 @@ class FileActionResult {
 class FileManagerBrowserController extends GetxController {
   final _apiClient = Get.find<ApiClient>();
   final _log = Get.find<AppLog>();
+  ServerApiVersionService get _serverApiVersionService =>
+      Get.find<ServerApiVersionService>();
 
   /// 当前路径（本页）
   final currentPath = '/'.obs;
@@ -551,7 +554,12 @@ class FileManagerBrowserController extends GetxController {
     }
 
     if (normalizedTmdbId.isNotEmpty) {
-      payload['tmdbid'] = normalizedTmdbId;
+      if (await _serverApiVersionService.isV3()) {
+        payload['media_source'] = 'themoviedb';
+        payload['media_id'] = normalizedTmdbId;
+      } else {
+        payload['tmdbid'] = normalizedTmdbId;
+      }
     }
 
     if (normalizedPart.isNotEmpty) {

--- a/lib/modules/storage/controllers/storage_list_controller.dart
+++ b/lib/modules/storage/controllers/storage_list_controller.dart
@@ -2,8 +2,9 @@ import 'package:get/get.dart';
 import 'package:moviepilot_mobile/applog/app_log.dart';
 import 'package:moviepilot_mobile/modules/media_organize/models/media_organize_models.dart';
 import 'package:moviepilot_mobile/services/api_client.dart';
+import 'package:moviepilot_mobile/services/server_api_version_service.dart';
 
-/// 存储使用情况（API: /api/v1/storage/usage/{type}）
+/// 存储使用情况
 class StorageUsage {
   const StorageUsage({
     required this.total,
@@ -26,10 +27,12 @@ class StorageUsage {
 
 /// 存储列表页 Controller
 /// 使用 /api/v1/system/setting/Storages 获取 StorageSetting 列表
-/// 使用 /api/v1/storage/usage/{type} 获取各存储的使用信息
+/// 获取各存储的使用信息
 class StorageListController extends GetxController {
   final _apiClient = Get.find<ApiClient>();
   final _log = Get.find<AppLog>();
+  ServerApiVersionService get _serverApiVersionService =>
+      Get.find<ServerApiVersionService>();
 
   final storages = <StorageSetting>[].obs;
   final storageNameMap = <String, String>{}.obs;
@@ -108,9 +111,17 @@ class StorageListController extends GetxController {
 
   Future<StorageUsage?> _loadUsage(String type) async {
     try {
-      final response = await _apiClient.get<dynamic>(
-        '/api/v1/storage/usage/$type',
-      );
+      final isV3 = await _serverApiVersionService.isV3();
+      final response = isV3
+          ? await _apiClient.postJson<dynamic>(
+              '/api/v1/storage/manage',
+              {
+                'target': _storageUsageTarget(type),
+                'action': 'usage',
+                'params': <String, dynamic>{},
+              },
+            )
+          : await _apiClient.get<dynamic>('/api/v1/storage/usage/$type');
       final status = response.statusCode ?? 0;
       if (status >= 400) return null;
 
@@ -127,6 +138,8 @@ class StorageListController extends GetxController {
       return null;
     }
   }
+
+  String _storageUsageTarget(String type) => type;
 
   /// 根据 storage type 获取显示名称
   String getStorageName(String? type) {

--- a/lib/modules/subscribe/controllers/subscribe_controller.dart
+++ b/lib/modules/subscribe/controllers/subscribe_controller.dart
@@ -580,7 +580,13 @@ class SubscribeController extends GetxController {
     if (fullPayload['doubanid'] is int) {
       fullPayload['doubanid'] = fullPayload['doubanid'].toString();
     }
-    final response = await _apiClient.put('/api/v1/subscribe/', fullPayload);
+    final requestPayload = await subscribeService.prepareSubscribePayload(
+      fullPayload,
+    );
+    final response = await _apiClient.put(
+      '/api/v1/subscribe/',
+      requestPayload,
+    );
     if (response.statusCode == null || response.statusCode! >= 400) {
       return false;
     }
@@ -710,20 +716,16 @@ class SubscribeController extends GetxController {
     String? tmdbid,
     String? year = '',
   }) async {
-    final payload = {
-      'bangumiid': bangumiid,
-      'best_version': bestVersion,
-      'doubanid': doubanid,
-      'episode_group': episodeGroup,
-      'mediaid': mediaid,
-      'name': name,
-      'season': season,
-      'tmdbid': tmdbid,
-      'year': year,
-    };
-    final resp = await subscribeService.submitSubscribe(
-      'movie',
-      payload: payload,
+    final resp = await subscribeService.submitMovieSubscribe(
+      bangumiid: bangumiid,
+      bestVersion: bestVersion,
+      doubanid: doubanid,
+      episodeGroup: episodeGroup,
+      mediaid: mediaid,
+      name: name,
+      season: season,
+      tmdbid: tmdbid,
+      year: year,
     );
     if (resp.success == true) {
       await _notifyMultifunctionSubscribeChanged();
@@ -740,18 +742,16 @@ class SubscribeController extends GetxController {
     String? tmdbid,
     String? year = '',
   }) async {
-    final payload = {
-      'doubanid': doubanid,
-      'episode_group': episode_group,
-      'mediaid': mediaid,
-      'name': name,
-      'season': season,
-      'tmdbid': tmdbid,
-      'year': year,
-      'best_version': 0,
-      'type': '电视剧',
-    };
-    final resp = await subscribeService.submitSubscribe('tv', payload: payload);
+    final resp = await subscribeService.submitTvSubscribe(
+      doubanid: doubanid,
+      episode_group: episode_group,
+      mediaid: mediaid,
+      name: name,
+      season: season,
+      tmdbid: tmdbid,
+      year: year,
+      bestVersionFull: null,
+    );
     if (resp.success == true) {
       await _notifyMultifunctionSubscribeChanged();
     }

--- a/lib/modules/subscribe/controllers/subscribe_service.dart
+++ b/lib/modules/subscribe/controllers/subscribe_service.dart
@@ -140,7 +140,7 @@ class SubscribeService extends GetxService {
     }
     try {
       final path = '/api/v1/subscribe/';
-      final requestPayload = await _prepareSubscribePayload(payload);
+      final requestPayload = await prepareSubscribePayload(payload);
       final response = await _apiClient.post(path, data: requestPayload);
       if (response.statusCode == 200) {
         return SubscribeSubmitResp.fromJson(response.data);
@@ -204,7 +204,7 @@ class SubscribeService extends GetxService {
     String? tmdbid,
     String? year = '',
     int bestVersion = 0,
-    int bestVersionFull = 1,
+    int? bestVersionFull = 1,
   }) async {
     final payload = {
       'doubanid': doubanid,
@@ -215,7 +215,7 @@ class SubscribeService extends GetxService {
       'tmdbid': tmdbid,
       'year': year,
       'best_version': bestVersion,
-      'best_version_full': bestVersionFull,
+      if (bestVersionFull != null) 'best_version_full': bestVersionFull,
       'type': '电视剧',
     };
     final isV3 = await _serverApiVersionService.isV3();
@@ -363,7 +363,7 @@ class SubscribeService extends GetxService {
     payload.remove('mediaid');
   }
 
-  Future<Map<String, dynamic>> _prepareSubscribePayload(
+  Future<Map<String, dynamic>> prepareSubscribePayload(
     Map<String, dynamic> payload,
   ) async {
     if (!await _serverApiVersionService.isV3()) {


### PR DESCRIPTION
接 #97 / #98 / #101。这次是一轮**全量审计**的结果：把 App 引用的 128 个 `/api/v1` 端点与 v2、v3 两份
`openapi.json` 逐一交叉比对，再对全部 schema 做字段删除 diff，把剩下的 v3 不兼容点一次清掉。

## 问题：v3 删除的请求体字段会被静默忽略

```
Body_add_api_v1_download_add_post   tmdbid, doubanid, bangumiid, anilistid
Body_download_subtitle_...          tmdbid, doubanid, bangumiid, anilistid
ManualTransferItem                  tmdbid, doubanid, bangumiid, anilistid
Subscribe                           tmdbid, doubanid, bangumiid, anilistid, mediaid
SubscribeShare                      tmdbid, doubanid, bangumiid, anilistid
DownloadHistory / TransferHistory   tmdbid, imdbid, tvdbid, doubanid, bangumiid, anilistid
MetaInfo                            tmdbid, doubanid, bangumiid, anilistid
TorrentInfo                         imdbid
```

这些字段在 v3 会被 pydantic 直接忽略，**不会报错**，所以表现是功能静默失效：下载任务、手动整理、
订阅创建与更新都丢掉用户指定的媒体身份，服务端只能退回按文件名识别。v3 用成对的
`media_source` + `media_id` 取代它们（半对会被拒绝）。

## 改动（5 处，均只在探测到 v3 时生效）

| 位置 | v3 行为 |
|---|---|
| `POST /download/add` | `tmdbid` → `media_source` + `media_id` |
| `POST /transfer/manual` | 同上 |
| 订阅创建 | `subscribe_controller` 里**遗漏的第二套** `submitMovie/TvSubscribe` 改为复用 `subscribe_service` 中已适配 v3 的实现 |
| `PUT /subscribe/` | 复用 `prepareSubscribePayload`；推导不出身份时新旧字段一律不发送，避免半对身份触发 422 |
| 存储用量 | `GET /storage/usage/{type}` **在 v3 已被删除**，改走 `POST /storage/manage {target, action:"usage"}` |

订阅那两处原本是 `subscribe_controller` 和 `subscribe_service` 各有一份几乎相同的实现，
#97 只改到了 service 那份。这次让 controller 直接复用 service，顺带消掉重复。
为保证 v2 请求体逐字不变，`best_version_full` 改成可空、为空时不写入该键。

`POST /download/subtitle` 经确认请求体本就不含旧媒体 ID，未改动。

## v2 兼容

全部改动都在 `if (await isV3())` 分支内，v2 走原路径、原字段，请求体与改动前逐字一致。

## 已核对确认**不需要**改的

响应侧从裸数据变 envelope 的那批，#98 的解包在 `data` 为 Map 时用 `putIfAbsent` 保留了 `data` 键，
调用方原有的 `raw['data'][...]` 取值方式仍然成立，逐个验过：`history/transfer`（读 `data['list']`）、
`mediaserver/exists`（读 `data['item']['id']`）、`site/icon`（读 `data.icon`）、`torrent/cache`、
`system/env`、`system/modulelist`、`transfer/name`。

端点层面只有 `storage/usage` 一个消失，其余 127 个路径与方法都还在。

## 验证

`flutter analyze`：0 error，本次改动文件未新增 warning/info。

⚠️ 一处未实测：`/storage/manage` 的 `target` 我按 schema 推断传的是存储类型（原路径里的 `$type`），
写测试时服务端不可达，**没有连真实服务端验证过**。已单独封装便于调整，字段取不到时回落为零、不抛异常。
如果实际取值不同，改一处即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
